### PR TITLE
Add missing include for QButtonGroup

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -72,6 +72,7 @@
 #include <QGridLayout>
 #include <QMessageBox>
 #include <QTreeWidgetItemIterator>
+#include <QButtonGroup>
 
 #include "Common.h"
 #include "DialogAbout.h"


### PR DESCRIPTION
```
[  591s] src/MainWindow.cpp: In constructor 'MainWindow::MainWindow(QWidget*)':                                                                                           
[  591s] src/MainWindow.cpp:246:34: error: invalid use of incomplete type 'class QButtonGroup'                                                                            
[  591s]    _bgZoom = new QButtonGroup(this);                                                                                                                             
[  591s]                                   ^                                                                                                                              
[  591s] In file included from /usr/include/qt5/QtWidgets/qpushbutton.h:44,                                                                                               
[  591s]                  from /usr/include/qt5/QtWidgets/QPushButton:1,                                                                                                  
[  591s]                  from .ui/ui_DialogAbout.h:18,                                                                                                                   
[  591s]                  from include/DialogAbout.h:50,                                                                                                                  
[  591s]                  from src/MainWindow.cpp:77:                                                                                                                     
[  591s] /usr/include/qt5/QtWidgets/qabstractbutton.h:53:7: note: forward declaration of 'class QButtonGroup'                                                             
[  591s]  class QButtonGroup;                                                                                                                                             
[  591s]        ^~~~~~~~~~~~
```