### PR TITLE
Add $$GMIC_LIB_PATH qmake variable

### DIFF
--- a/zart.pro
+++ b/zart.pro
@@ -43,6 +43,10 @@ defined(GMIC_PATH, var):!exists( $$GMIC_PATH/gmic.cpp ) {
 }
 message("G'MIC repository was found ("$$GMIC_PATH")")
 
+!defined(GMIC_LIB_PATH, var) {
+  GMIC_LIB_PATH = $$GMIC_PATH
+}
+
 unix {
    VERSION = $$system(grep \"define.ZART_VERSION \" include/Common.h | sed -e \"s/.*VERSION //\")
 }
@@ -78,7 +82,7 @@ openmp {
 
 equals(GMIC_DYNAMIC_LINKING, "on" ) {
   message(Dynamic linking with libgmic)
-  LIBS += $$GMIC_PATH/libgmic.so
+  LIBS += $$GMIC_LIB_PATH/libgmic.so
 }
 
 equals(GMIC_DYNAMIC_LINKING, "off" ) {


### PR DESCRIPTION
Add a `GMIC_LIB_PATH` variable to the qmake build system, so it is possible to specify where to find the dynamic gmic library, in the same way it is possible in gmic-qt. This way, one can build gmic with builddir!=srcdir, and build zart using libgmic (which would then be in a different location than the gmic sources).

If not specified, it falls back to `$$GMIC_PATH`, so behaving the same as before.