### PR TITLE
Change 'gmic_build' to 'gmic_core'.

### DIFF
--- a/zart.pro
+++ b/zart.pro
@@ -117,7 +117,7 @@ equals(GMIC_DYNAMIC_LINKING, "on" ) {
 equals(GMIC_DYNAMIC_LINKING, "off" ) {
  HEADERS += $$GMIC_PATH/gmic_stdlib.h
  SOURCES += $$GMIC_PATH/gmic.cpp
- DEFINES += gmic_build
+ DEFINES += gmic_core
 }
 
 #


### PR DESCRIPTION
Make zart compile for next version 3.0.2 of G'MIC.