### PR TITLE
Make 'gmic_stdlib_community' default for ZArt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - date -u
   - uname -a
   - git clone --depth=1 https://github.com/dtschump/gmic.git gmic
-  - make -C gmic/src CImg.h gmic_stdlib.h
+  - make -C gmic/src CImg.h gmic_stdlib_community.h
 
 install:
   - if [ -z "$TRAVIS_OS_NAME" -o "$TRAVIS_OS_NAME" = "linux" ]; then

--- a/zart.pro
+++ b/zart.pro
@@ -115,7 +115,7 @@ equals(GMIC_DYNAMIC_LINKING, "on" ) {
 }
 
 equals(GMIC_DYNAMIC_LINKING, "off" ) {
- HEADERS += $$GMIC_PATH/gmic_stdlib.h
+ HEADERS += $$GMIC_PATH/gmic_stdlib_community.h
  SOURCES += $$GMIC_PATH/gmic.cpp
  DEFINES += gmic_core
 }


### PR DESCRIPTION
File 'gmic_stdlib.h' has been completely removed in G'MIC.
Now all G'MIC interfaces rely on the  `gmic_stdlib_community.h` file.